### PR TITLE
Upgrades AWS SDK to V2.

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -4,24 +4,32 @@ driver_plugin: vagrant
 platforms:
 - name: centos-6.3
 - name: ubuntu-12.04
+- name: ubuntu-14.04
 
 suites:
 - name: default
   run_list: ["recipe[artifact_test]"]
-  attributes: 
+  attributes:
     artifact_test:
       version: "1.2.3"
       location: "/tmp/kitchen-chef-solo/cookbooks/artifact/fixtures/artifact_test-1.2.3.tgz"
 - name: forcing
   run_list: ["recipe[artifact_test::default]", "recipe[artifact_test::force_install]"]
-  attributes: 
+  attributes:
     artifact_test:
       version: "1.2.3"
       location: "/tmp/kitchen-chef-solo/cookbooks/artifact/fixtures/artifact_test-1.2.3.tgz"
 - name: file
   run_list: ["recipe[artifact_test::file]"]
-- name : nexus-file
+- name: nexus-file
   run_list: ["recipe[artifact_test::file]"]
   attributes:
     artifact_test:
       file_url: "com.test:mytest:1.0.0:tgz"
+- name: s3-file
+  run_list: ["recipe[artifact_test]"]
+  attributes:
+    artifact_test:
+      version: "1.2.3"
+      location: "s3://s3-us-east-1.amazonaws.com/bucket/path/to/file.tgz"
+      deploy_to: "1.2.3"

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ group :test do
   gem 'foodcritic', '~> 3.0'
   gem 'rubocop', '~> 0.19'
   gem 'chefspec', '~> 3.4.0'
-  gem 'aws-sdk'
+  gem 'aws-sdk', '~> 2'
 end
 
 group :integration do

--- a/libraries/chef_artifact.rb
+++ b/libraries/chef_artifact.rb
@@ -8,22 +8,22 @@ class Chef
     module File
 
       # Returns true if the given file is a symlink.
-      # 
+      #
       # @param  path [String] the path to the file to test
-      # 
+      #
       # @return [Boolean]
       def symlink?(path)
         if windows?
           require 'chef/win32/file'
           return Chef::ReservedNames::Win32::File.symlink?(path)
         end
-        ::File.symlink?(path)        
+        ::File.symlink?(path)
       end
 
       # Returns the value of the readlink method.
-      # 
+      #
       # @param  path [String] the path to a symlink
-      # 
+      #
       # @return [String] the path that the symlink points to
       def readlink(path)
         if windows?
@@ -34,11 +34,11 @@ class Chef
       end
 
       # Generates a command to execute that either uses the Unix cp
-      # command or the Windows copy command. 
+      # command or the Windows copy command.
       #
       # @param  source [String] the file to copy
       # @param  destination [String] the path to copy the source to
-      # 
+      #
       # @return [String] a useable command to copy a file
       def copy_command_for(source, destination)
         if windows?
@@ -62,7 +62,7 @@ class Chef
       #
       # @param  environment [String] the environment
       # @param  source [String] the deployment source to load configuration for
-      # 
+      #
       # @return [Chef::DataBagItem] the data bag item
       def data_bag_config_for(environment, source)
         data_bag_item = if Chef::Config[:solo]
@@ -92,24 +92,35 @@ class Chef
           require 'aws-sdk'
           config = data_bag_config_for(node.chef_environment, DATA_BAG_AWS)
           s3_endpoint, bucket_name, object_name = parse_s3_url(source_file)
-
+          endpoint_parts = s3_endpoint.split('.')
+          endpoint = endpoint_parts[0]
+          # Set Region
+          region = endpoint[3,-1]
+          if region.nil? || region == 'external-1'
+            region = 'us-east-1'
+          end
+          # Set Config
+          Aws.config[:region] = region
           if config.empty?
-            AWS.config(:s3 => { :endpoint => s3_endpoint })
+            Chef::Log.debug("Config not found for databag AWS. Using Instance Profile Credentials")
+            Aws.config[:credentials] = Aws::InstanceProfileCredentials.new()
           else
-            AWS.config(:access_key_id => config['access_key_id'],
-                       :secret_access_key => config['secret_access_key'],
-                       :s3 => { :endpoint => s3_endpoint })
+            Chef::Log.debug("Config found for databag AWS. Using databag for credentials")
+            Aws.config[:credentials] = Aws::Credentials.new(
+                config['access_key_id'],
+                config['secret_access_key']
+            )
           end
-
-          object = get_s3_object(bucket_name, object_name)
-
           Chef::Log.debug("Downloading #{object_name} from S3 bucket #{bucket_name}")
-          ::File.open(destination_file, 'wb') do |file|
-            object.read do |chunk|
-              file.write(chunk)
-            end
-            Chef::Log.debug("File #{destination_file} is #{file.size} bytes on disk")
-          end
+          # Retrieve S3 Object
+          client = Aws::S3::Client.new()
+          object = client.get_object(
+              response_target: destination_file,
+              bucket: bucket_name,
+              key: object_name
+          )
+          Chef::Log.debug("File #{destination_file} is #{object.content_length} bytes on disk")
+
         rescue URI::InvalidURIError
           Chef::Log.warn("Expected an S3 URL but found #{source_file}")
           raise
@@ -132,30 +143,11 @@ class Chef
         [s3_endpoint, bucket_name, object_name]
       end
 
-      # Given a bucket and object name - fetches the object from S3
-      #
-      # @example
-      #   object = Chef::Artifact.get_s3_object('my-bucket', 'my-file.txt')
-      #
-      # @param  bucket_name [String] Name of the S3 bucket
-      # @param  object_name [String] Name of the S3 object
-      #
-      # @return [AWS::S3::S3Object] An S3 Object
-      def get_s3_object(bucket_name, object_name)
-        s3_client = AWS::S3.new()
-        bucket = s3_client.buckets[bucket_name]
-        raise S3BucketNotFoundError.new(bucket_name) unless bucket.exists?
-
-        object = bucket.objects[object_name]
-        raise S3ArtifactNotFoundError.new(bucket_name, object_name) unless object.exists?
-        object
-      end
-
       # Returns true when the artifact is believed to be from a
       # Nexus source.
       #
       # @param  location [String] the artifact_location
-      # 
+      #
       # @return [Boolean] true when the location is a colon-separated value
       def from_nexus?(location)
         !from_http?(location) && location.split(":").length > 2
@@ -173,9 +165,9 @@ class Chef
 
       # Returns true when the artifact is believed to be from an
       # http source.
-      # 
+      #
       # @param  location [String] the artifact_location
-      # 
+      #
       # @return [Boolean] true when the location matches http or https.
       def from_http?(location)
         location_of_type(location, %w(http https))
@@ -218,10 +210,10 @@ class Chef
       # indicated by the 'current' key is returned.
       #
       # @param  deploy_to_dir [String] the directory where an artifact is installed
-      # 
+      #
       # @example
       #   Chef::Artifact.get_current_deployed_version("/opt/my_deploy_dir") => "2.0.65"
-      # 
+      #
       # @return [String] the currently deployed version of the given artifact
       def get_current_deployed_version(deploy_to_dir)
 
@@ -238,12 +230,12 @@ class Chef
       end
 
       # Looks for the given data bag in the cache and if not found, will load a
-      # data bag item named for the chef_environment, '_wildcard', or the old 
+      # data bag item named for the chef_environment, '_wildcard', or the old
       # 'nexus' value.
       #
       # @param  environment [String] the environment
       # @param  data_bag [String] the data bag to load
-      # 
+      #
       # @return [Chef::Mash] the data bag item in Mash form
       def encrypted_data_bag_for(environment, data_bag)
         @encrypted_data_bags = {} unless @encrypted_data_bags
@@ -268,7 +260,7 @@ class Chef
       # Loads an entry from the encrypted_data_bags class variable.
       #
       # @param data_bag [String] the data bag to find
-      # 
+      #
       # @return [type] [description]
       def get_from_data_bags_cache(data_bag)
         encrypted_data_bags[data_bag]
@@ -280,10 +272,10 @@ class Chef
       #
       # @param  data_bag [String]
       # @param  data_bag_item [String]
-      # 
+      #
       # @raise [Chef::Artifact::DataBagEncryptionError] when the data bag cannot be decrypted
       #   or transformed into a Mash for some reason (Chef 10 vs Chef 11 data bag changes).
-      # 
+      #
       # @return [Chef::Mash]
       def encrypted_data_bag_item(data_bag, data_bag_item)
         Mash.from_hash(Chef::EncryptedDataBagItem.load(data_bag, data_bag_item).to_hash)

--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer       "Riot Games"
 maintainer_email "kallan@riotgames.com"
 license          "Apache 2.0"
 description      "Provides your cookbooks with the Artifact Deploy LWRP"
-version          "1.12.1"
+version          "1.13.0"
 
 supports "centos"
 supports "redhat"

--- a/providers/deploy.rb
+++ b/providers/deploy.rb
@@ -82,7 +82,8 @@ def load_current_resource
     end
 
     chef_gem "aws-sdk" do
-      version "1.29.0"
+      version "2.1.32"
+      action :install
     end
 
     @artifact_version = @new_resource.version

--- a/providers/file.rb
+++ b/providers/file.rb
@@ -3,7 +3,7 @@
 # Provider:: file
 #
 # Author:: Kyle Allan (<kallan@riotgames.com>)
-# 
+#
 # Copyright 2013, Riot Games
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -38,9 +38,12 @@ def load_current_resource
     @nexus_configuration = new_resource.nexus_configuration
     @nexus_connection = Chef::Artifact::Nexus.new(node, nexus_configuration)
   elsif Chef::Artifact.from_s3?(@new_resource.location)
+
     chef_gem "aws-sdk" do
-      version "1.29.0"
+      version "2.1.32"
+      action :install
     end
+
   end
   @file_location = new_resource.location
   @file_path = new_resource.path
@@ -147,7 +150,7 @@ private
     execute_run_proc("artifact_file", new_resource, name)
   end
 
-  # Scrubs the file_location and returns the path to 
+  # Scrubs the file_location and returns the path to
   # the resource's checksum file.
   #
   # @return [String]
@@ -178,7 +181,7 @@ private
     ::File.exists?(cached_checksum)
   end
 
-  # Writes a file to file_cache_path. This file contains a SHA256 digest of the 
+  # Writes a file to file_cache_path. This file contains a SHA256 digest of the
   # artifact file. Returns the result of the file.puts command, which will be nil.
   #
   # @return [NilClass]

--- a/spec/libraries/chef_artifact_spec.rb
+++ b/spec/libraries/chef_artifact_spec.rb
@@ -30,7 +30,7 @@ describe Chef::Artifact do
 
       it "loads an encrypted data bag" do
         expect(data_bag_config_for.symbolize_keys).to eq(data_bag_item)
-      end      
+      end
     end
 
     context "when loading legacy data bag format" do
@@ -137,7 +137,7 @@ describe Chef::Artifact do
       it "looks for the '_wildcard' data bag item" do
         described_class.stub(:encrypted_data_bag_item).and_return(nil, data_bag_item)
         described_class.should_receive(:encrypted_data_bag_item).with(data_bag, "_wildcard")
-        expect(encrypted_data_bag_for).to eq(data_bag_item)        
+        expect(encrypted_data_bag_for).to eq(data_bag_item)
       end
 
       it "looks for the 'nexus' data bag item" do


### PR DESCRIPTION
This commit upgrades the AWS SDK to version 2 and adds a test suite for testing artifact deploys with Amazon s3.

To test the artifact deploys, you'll need to create a databag for that test suite and/or deploy to Amazon. First, it will try to authorize the user through databags. If it is unable to find an aws databag, it will switch to using the instance profile to pull the informmation directly from the Amazon EC2 instance.